### PR TITLE
added attachBytes to Multipart.scala

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,7 @@ licenses := Seq(
 
 homepage := Some(url("https://github.com/softprops/%s/#readme".format(name.value)))
 
-scalaVersion := "2.9.3"
+scalaVersion := "2.10.2"
 
 crossScalaVersions := Seq("2.9.3", "2.10.2")
 

--- a/src/main/scala/content.scala
+++ b/src/main/scala/content.scala
@@ -4,6 +4,7 @@ import javax.activation.{ DataHandler, FileDataSource }
 import javax.mail.internet.{ MimeBodyPart, MimeMultipart }
 import java.io.File
 import java.nio.charset.Charset
+import javax.mail.util.ByteArrayDataSource
 
 sealed trait Content
 
@@ -42,6 +43,12 @@ case class Multipart(
     add(new MimeBodyPart {
       setDataHandler(new DataHandler(new FileDataSource(file)))
       setFileName(name.getOrElse(file.getName))
+    })
+
+  def attachBytes(bytes: Array[Byte], name: String, mimeType: String) =
+    add(new MimeBodyPart {
+      setDataHandler(new DataHandler(new ByteArrayDataSource(bytes, mimeType)))
+      setFileName(name)
     })
 
   def parts =


### PR DESCRIPTION
OK, so I've done a small amount of work to be able to attach a byte[] instead of just a file like so:

``` scala
mailer(Envelope.from("you" `@` "work.com")
         .to("boss" `@` "work.com")
         .subject("tps report")
         .content(Multipart()
           .attachBytes("ASCII TPS Template".getBytes(), "ascii-tps-template.txt", "text/plain")
           .html("<html><body><h1>IT'S IMPORTANT</h1></body></html>")))
           .onSuccess {
             case _ => println("delivered report")
           }
```

I'm pretty new to Scala, so feel free to hack away to your liking!
