### PR TITLE
Mail session should use system properties initially

### DIFF
--- a/src/main/scala/sessions.scala
+++ b/src/main/scala/sessions.scala
@@ -23,7 +23,8 @@ object Session {
     def socketFactory(cls: String) = copy(_socketFactory = Some(cls))
     def sslSocketFactory = socketFactory("javax.net.ssl.SSLSocketFactory")
     def apply() =
-      mailer.copy(_session = MailSession.getInstance(new Properties {
+      mailer.copy(_session = MailSession.getInstance(
+        new Properties(System.getProperties) {
         _debug.map(d => put("mail.smtp.debug", d.toString))
         _auth.map(a => put("mail.smtp.auth", a.toString))
         // enable ESMTP


### PR DESCRIPTION
Hi @softprops,
please accept the patch which enables to configure default behavior of mail session via system properties (as per plain Java use), e.g. those described in https://javamail.java.net/nonav/docs/api/com/sun/mail/smtp/package-summary.html

thanks,
-tomas
