### PR TITLE
Fixed implicit conversion of email addresses

### DIFF
--- a/src/main/scala/package.scala
+++ b/src/main/scala/package.scala
@@ -1,12 +1,13 @@
 import javax.mail.internet.InternetAddress
+import scala.language.implicitConversions
 
 /** An agreeable email interface for scala. */
 package object courier {
 
+  implicit def str2Address(name: String) = new InternetAddress(name)
+
   implicit class addr(name: String){
     def `@`(domain: String): InternetAddress = new InternetAddress(s"$name@$domain")
     def at = `@` _
-    /** In case whole string is email address already */
-    def addr = new InternetAddress(name)
   }
 }


### PR DESCRIPTION
The implicit conversion of strings to instances of `InternetAddress` would not work as expected.