### PR TITLE
Changes to the doc to address #46

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,5 @@ worker*.log
 /bin
 .creds.sh
 project/.gnupg/
+.bloop/
+.metals/

--- a/README.md
+++ b/README.md
@@ -83,36 +83,6 @@ Since courier is based on JavaMail, you can use [Mock JavaMail](https://java.net
 libraryDependencies += "org.jvnet.mock-javamail" % "mock-javamail" % "1.9" % "test"
 ```
 
-Having this in your test dependencies will automatically enable Mock JavaMail during tests. You can then test for email sends, etc.
-
-```scala
-import courier._
-import org.specs2.mutable.Specification
-import scala.concurrent.duration._
-
-// Need NoTimeConversions to prevent conflict with scala.concurrent.duration._
-class MailSpec extends Specification with NoTimeConversions {
-  "the mailer" should {
-  	"send an email" in {
-  	  val mailer = Mailer("localhost", 25)()
-  	  val future = mailer(Envelope.from("someone@example.com".addr)
-          	.to("mom@gmail.com".addr)
-          	.cc("dad@gmail.com".addr)
-          	.subject("miss you")
-          	.content(Text("hi mom")))
-
-          Await.ready(future, 5.seconds)
-          val momsInbox = Mailbox.get("mom@gmail.com")
-          momsInbox.size === 1
-          val momsMsg = momsInbox.get(0)
-          momsMsg.getContent === "hi mom"
-          momsMsg.getSubject === "miss you"
-        }
-  	}
-  }
-}
-```
-
-[Here](https://community.oracle.com/blogs/kohsuke/2007/04/26/introducing-mock-javamail-project) is an excellent article on using Mock JavaMail.
+With this library, you should, given a little bit of boilerplate, be able to set a test against a mocked Mailbox. This repo contains [an example](src/test/scala/mailspec.scala).
 
 (C) Doug Tangren (softprops) and others, 2013-2018

--- a/build.sbt
+++ b/build.sbt
@@ -31,7 +31,7 @@ lazy val commonSettings = releaseSettings ++ Seq(
   description := "deliver electronic mail with scala",
   licenses := Seq(("MIT", url("https://opensource.org/licenses/MIT"))),
   homepage := Some(url("https://github.com/dmurvihill/courier")),
-  crossScalaVersions := Seq("2.10.7", "2.11.12", "2.12.7"),
+  crossScalaVersions := Seq("2.10.7", "2.11.12", "2.12.8"),
   scalaVersion := crossScalaVersions.value.last,
   scmInfo := Some(
     ScmInfo(
@@ -82,7 +82,7 @@ lazy val root = (project in file("."))
     libraryDependencies ++= Seq(
       "com.sun.mail"      % "javax.mail"      % "1.6.2",
       "javax.activation"  % "activation"      % "1.1.1",
-      "org.bouncycastle"  % "bcpkix-jdk15on"  % "1.60" % Optional,
-      "org.bouncycastle"  % "bcmail-jdk15on"  % "1.60" % Optional
+      "org.bouncycastle"  % "bcpkix-jdk15on"  % "1.61" % Optional,
+      "org.bouncycastle"  % "bcmail-jdk15on"  % "1.61" % Optional
     )
   )

--- a/build.sbt
+++ b/build.sbt
@@ -83,6 +83,9 @@ lazy val root = (project in file("."))
       "com.sun.mail"      % "javax.mail"      % "1.6.2",
       "javax.activation"  % "activation"      % "1.1.1",
       "org.bouncycastle"  % "bcpkix-jdk15on"  % "1.61" % Optional,
-      "org.bouncycastle"  % "bcmail-jdk15on"  % "1.61" % Optional
+      "org.bouncycastle"  % "bcmail-jdk15on"  % "1.61" % Optional,
+      "org.scalactic"     %% "scalactic"      % "3.0.5" % Test,
+      "org.scalatest"     %% "scalatest"      % "3.0.5" % Test,
+      "org.jvnet.mock-javamail" % "mock-javamail" % "1.9" % Test
     )
   )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.2-1")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.3")
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0")
-// addSbtPlugin("org.tpolecat" % "tut-plugin" % "0.6.9")
+addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.1.0-M9")
+addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.3.4")

--- a/src/test/scala/mailspec.scala
+++ b/src/test/scala/mailspec.scala
@@ -1,0 +1,38 @@
+package courier
+
+import java.util.Properties
+
+import javax.mail.Provider
+import org.jvnet.mock_javamail.{Mailbox, MockTransport}
+import org.scalatest._
+
+import scala.concurrent.Await
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration._
+
+class MockedSMTPProvider extends Provider(Provider.Type.TRANSPORT, "mocked", classOf[MockTransport].getName, "Mock", null)
+
+class MailSpec extends WordSpec {
+  private val mockedSession = javax.mail.Session.getDefaultInstance(new Properties() {{
+    put("mail.transport.protocol.rfc822", "mocked")
+  }})
+  mockedSession.setProvider(new MockedSMTPProvider)
+
+  "the mailer" should {
+    "send an email" in {
+      val mailer = Mailer(mockedSession)
+      val future = mailer(Envelope.from("someone@example.com".addr)
+            .to("mom@gmail.com".addr)
+            .cc("dad@gmail.com".addr)
+            .subject("miss you")
+            .content(Text("hi mom")))
+
+      Await.ready(future, 5.seconds)
+      val momsInbox = Mailbox.get("mom@gmail.com")
+      momsInbox.size === 1
+      val momsMsg = momsInbox.get(0)
+      momsMsg.getContent === "hi mom"
+      momsMsg.getSubject === "miss you"
+    }
+  }
+}


### PR DESCRIPTION
The doc appeared to be out of date. Whatever it is that made the mock the default transporter did not seem to work anymore. Since the library does not seem to be maintained much anymore (no need for it I think). I wrote a test as an example with the help of Arminea.

https://github.com/dmurvihill/courier/issues/46