### PR TITLE
Migration scala3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,12 +22,12 @@ lazy val publisherSettings = Seq(
 lazy val releaseSettings = publisherSettings ++ credentialSettings
 
 lazy val commonSettings = releaseSettings ++ Seq(
-  version := "3.0.0",
+  version := "3.0.0-RC1",
   organization := "com.github.daddykotex",
   description := "deliver electronic mail with scala",
   licenses := Seq(("MIT", url("https://opensource.org/licenses/MIT"))),
   homepage := Some(url("https://github.com/dmurvihill/courier")),
-  crossScalaVersions := Seq("2.11.12", "2.12.12", "2.13.3"),
+  crossScalaVersions := Seq("2.11.12", "2.12.12", "2.13.3", "0.27.0-RC1"),
   scalaVersion := crossScalaVersions.value.last,
   scmInfo := Some(
     ScmInfo(
@@ -53,14 +53,14 @@ lazy val commonSettings = releaseSettings ++ Seq(
 
 lazy val cFlags = Seq(
   scalacOptions ++= (CrossVersion.partialVersion(scalaVersion.value) match {
-    case Some((2, n)) if n == 11 =>
+    case Some((2, 11)) =>
       Seq(
         "-language:existentials",
         "-language:higherKinds",
         "-language:implicitConversions",
         "-Ypartial-unification"
       )
-    case Some((2, n)) if n == 12 =>
+    case Some((2, 12)) =>
       ScalacOptions.All ++ Seq(
         "-language:existentials",
         "-language:higherKinds",
@@ -75,9 +75,16 @@ lazy val cFlags = Seq(
         "-Ywarn-nullary-override",
         "-Ywarn-nullary-unit"
       )
-    case _ =>
+    case Some((2, 13)) =>
       ScalacOptions.All
-  })
+    case Some((0, 27)) =>
+      Seq.empty
+    case Some(_) | None =>
+      throw new IllegalArgumentException("Unable to figure out scalacOptions")
+  }),
+  scalacOptions in Test := {
+    if (isDotty.value) { Seq("-language:implicitConversions") } else { Seq.empty }
+  }
 )
 
 lazy val scalaTestVersion = "3.2.2"

--- a/build.sbt
+++ b/build.sbt
@@ -22,12 +22,12 @@ lazy val publisherSettings = Seq(
 lazy val releaseSettings = publisherSettings ++ credentialSettings
 
 lazy val commonSettings = releaseSettings ++ Seq(
-  version := "2.0.0",
+  version := "3.0.0",
   organization := "com.github.daddykotex",
   description := "deliver electronic mail with scala",
   licenses := Seq(("MIT", url("https://opensource.org/licenses/MIT"))),
   homepage := Some(url("https://github.com/dmurvihill/courier")),
-  crossScalaVersions := Seq("2.11.12", "2.12.8", "2.13.0"),
+  crossScalaVersions := Seq("2.11.12", "2.12.12", "2.13.3"),
   scalaVersion := crossScalaVersions.value.last,
   scmInfo := Some(
     ScmInfo(
@@ -80,7 +80,7 @@ lazy val cFlags = Seq(
   })
 )
 
-lazy val scalaTestVersion = "3.0.8"
+lazy val scalaTestVersion = "3.2.2"
 
 lazy val root = (project in file("."))
   .settings(commonSettings ++ cFlags)

--- a/project/ScalacOptions.scala
+++ b/project/ScalacOptions.scala
@@ -20,7 +20,6 @@ object ScalacOptions {
     "-Xlint:inaccessible",               // Warn about inaccessible types in method signatures.
     "-Xlint:infer-any",                  // Warn when a type argument is inferred to be `Any`.
     "-Xlint:missing-interpolator",       // A string literal appears to be missing an interpolator id.
-    "-Xlint:nullary-override",           // Warn when non-nullary `def f()' overrides nullary `def f'.
     "-Xlint:nullary-unit",               // Warn when nullary methods return Unit.
     "-Xlint:option-implicit",            // Option.apply used implicit view.
     "-Xlint:package-object-classes",     // Class or object defined in package object.

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.0-RC2
+sbt.version=1.4.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,4 @@
 addSbtPlugin("io.crashbox" % "sbt-gpg" % "0.2.0")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.3")
 addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.5.1")
+addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.4.1")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,3 @@
 addSbtPlugin("io.crashbox" % "sbt-gpg" % "0.2.0")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.3")
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.1.0-M9")
-addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.3.4")
+addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.5.1")

--- a/src/main/scala-0.27/compat.scala
+++ b/src/main/scala-0.27/compat.scala
@@ -1,0 +1,8 @@
+package courier
+
+object Compat {
+  def asJava[T](set: Set[T]): java.util.Set[T] = {
+    import scala.jdk.CollectionConverters._
+    set.asJava
+  }
+}

--- a/src/main/scala/defaults.scala
+++ b/src/main/scala/defaults.scala
@@ -6,6 +6,6 @@ import scala.concurrent.ExecutionContext
 
 object Defaults {
   val session = MailSession.getDefaultInstance(new Properties())
-  
-  implicit val executionContext = ExecutionContext.Implicits.global
+
+  implicit val executionContext: ExecutionContext = ExecutionContext.Implicits.global
 }

--- a/src/test/scala/mailspec.scala
+++ b/src/test/scala/mailspec.scala
@@ -5,6 +5,8 @@ import java.util.Properties
 import javax.mail.Provider
 import org.jvnet.mock_javamail.{Mailbox, MockTransport}
 import org.scalatest._
+import wordspec._
+import matchers._
 
 import scala.concurrent.Await
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -12,7 +14,7 @@ import scala.concurrent.duration._
 
 class MockedSMTPProvider extends Provider(Provider.Type.TRANSPORT, "mocked", classOf[MockTransport].getName, "Mock", null)
 
-class MailSpec extends WordSpec {
+class MailSpec extends AnyWordSpec with should.Matchers {
   private val mockedSession = javax.mail.Session.getDefaultInstance(new Properties() {{
     put("mail.transport.protocol.rfc822", "mocked")
   }})


### PR DESCRIPTION
First commit is to update a bunch of dependencies, including `org.scalatest.*` to support Dotty.

Then the second commit is the actual migration. There was one warning: the type missing on the implicit EC. I added a `scalacOptions` in test because scalatest test suites make a bunch of implicit conversions.