### PR TITLE
Add ability to override MimeMessage class

### DIFF
--- a/courier/src/main/scala/defaults.scala
+++ b/courier/src/main/scala/defaults.scala
@@ -2,10 +2,13 @@ package courier
 
 import javax.mail.{Session => MailSession}
 import java.util.Properties
+import javax.mail.internet.MimeMessage
 import scala.concurrent.ExecutionContext
 
 object Defaults {
   val session = MailSession.getDefaultInstance(new Properties())
+
+  val mimeMessageFactory: MailSession => MimeMessage = new MimeMessage(_)
 
   implicit val executionContext: ExecutionContext = ExecutionContext.Implicits.global
 }


### PR DESCRIPTION
In some cases it might be useful to specify custom MimeMessage class in
order to override methods inside it. For example some headers cannot
be overridden by Envelope.headers (e.g. `Message-ID`), because they will
be updated by calling `MimeMessage.saveChanges` later; in this specific
case the code sample will look like:

```
val mimeFactory: MailSession => MimeMessage = session =>
  new MimeMessage(session) {
    override def updateMessageID(): Unit =
      setHeader("Message-ID", "<some-very-unique-id@domain.com>")
  }
Mailer(mimeMessageFactory = mimeFactory).session.host(host).port(port)
// ... do whatever you want
```